### PR TITLE
Update index-en.html

### DIFF
--- a/index-en.html
+++ b/index-en.html
@@ -127,15 +127,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 	<h1 id="wb-cont" property="name">Example Application Form</h1>
 	<p>This form is not connected to a server - the data aren't really being collected. It's just for test purposes.</p>
 	<div class="wb-frmvld">
-		<form action="./exform2-en.html" method="get" id="validation-example" novalidate>
-			<fieldset>
-				<legend>Contact</legend>
-				<div class="form-group">
-					<label for="tel1" ><span class="field-name">Daytime Contact Number</span> (999-999-9999)</label>
-					<p id="tel1-desc">Provide your work telephone number or a mobile number with voice messaging. For this test session, remember to switch a few digits to protect your privacy.</p>
-					<input class="form-control" id="tel1" name="tel1" type="tel" data-rule-phoneus="true" placeholder="999-999-9999" aria-describedby="tel1-desc">
-				</div>
-			</fieldset>
+		<form action="./done-en.html" method="get" id="validation-example" novalidate>
 			<fieldset>
 				<legend>Browser</legend>
 				<div class="form-group">
@@ -151,8 +143,8 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 				</div>
 				<div class="form-group">
 					<div id="bversion-desc">
-						<p><b>Look up the version number of your browser.</b></p>
-						<p>For example, on Chrome, the version number might be 11.0.9600.17631. Just enter the first two digits - 11.</p>
+						<p><b>If you are viewing this on a computer, look up the version number of your browser.</b></p>
+						<p>On a phone, enter the type of phone - for example, iPhone 5S.</p>
 						<details class="mrgn-bttm-md">
 							<summary>How to find your browser version number</summary>
 							 <div class="modal-body">
@@ -171,7 +163,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 							</div>
 						</details>
 					</div>
-					<label for="bversion"><span class="field-name">Browser version number :</span> </label>
+					<label for="bversion"><span class="field-name">Browser version number or type of phone:</span> </label>
 					<input class="form-control" id="bversion" name="bversion" type="text" aria-describedby="bversion-desc">
 				</div>
 			</fieldset>


### PR DESCRIPTION
Remove telephone number field
Edit so phone users understand browser version number field
Redirect NEXT button from exform2-en to last 'Done' done-en page - once Datepicker is revised, the skipped pages will be reintegrated.
